### PR TITLE
Remove jdk and all python java interop

### DIFF
--- a/py3.6/Dockerfile
+++ b/py3.6/Dockerfile
@@ -7,15 +7,10 @@ RUN echo "deb http://httpredir.debian.org/debian stretch contrib" >> /etc/apt/so
 RUN apt-get update
 RUN apt-get install -y -qq node-less
 
-# Install JDK
-RUN  apt-get install -y -qq openjdk-8-jdk
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-
 # Upgrade pip
 RUN pip install --upgrade pip
 
 # Installing cython before, because needed to compile pyjnius in next step
-RUN pip install cython==0.26.1
 # Copy requirements to root and install
 COPY requirements.txt /app
 RUN pip install -r requirements.txt

--- a/py3.6/requirements.txt
+++ b/py3.6/requirements.txt
@@ -11,9 +11,6 @@ janrain-python-api==0.4.0
 Jinja2==2.10
 jinja2-cli==0.6.0
 mailer==0.8.1
-MarkupSafe==1.0
-#pyjnius==1.1.2.dev0
-git+https://github.com/kivy/pyjnius@d2ef91b73ee7dc6ae9ca3042fc1fc6de6565c237#egg=pyjnius
 pytz==2017.2
 PyYAML==4.2b2
 visitor==0.1.3


### PR DESCRIPTION
This kind of makes the name of this repo obsolete as we are removing the jdk in pyjdkngx ;)